### PR TITLE
Fix: comply with schemas from e58323a

### DIFF
--- a/evcc/states/wait_for_dc_charge_parameter_discovery_response.py
+++ b/evcc/states/wait_for_dc_charge_parameter_discovery_response.py
@@ -27,7 +27,7 @@ class WaitForDcChargeParameterDiscoveryResponse(DcEVState):
         extra_data = {}
         request = ScheduleExchangeReq()
         request.header = MessageHeaderType(self.session_parameters.session_id, int(time.time()))
-        request.maximum_supporting_points = 2048
+        request.maximum_supporting_points = 1024
         evse_data = payload.bpt_dc_cpdres_energy_transfer_mode
         request.dynamic_sereq_control_mode = self.controller.data_model.get_dynamic_sereq_control_mode()
         self.controller.data_model.evsemaximum_charge_power = evse_data.evsemaximum_charge_power


### PR DESCRIPTION
When verifying my decoder, I ran in the issue that ScheduleExchangeReq message couldn't be decoded. After some research I found a mismatch in schema updates but not in the code see: [e58323a 2048 -> 1024](https://github.com/EDF-Lab/EDF/commit/e58323a68d735f298b07c9fd91cd3fe225a73d11#diff-ab93920b7cfac88856af7e333da859276ac9caa5afaf9366fa94fb6e21a9fa6dL2417)

Ps, thanks for open-sourcing this project