### PR TITLE
Fixed typo on ev_dummy_controller.py that caused crash on GUI mode

### DIFF
--- a/evcc/ev_dummy_controller.py
+++ b/evcc/ev_dummy_controller.py
@@ -97,7 +97,7 @@ class EVEmulator(DcEVDataModel):
     evsemaximum_discharge_power: Optional[DcRationalNumberType] = DcRationalNumberType(0, 0)
     _evsemaximum_discharge_power: Optional[DcRationalNumberType] = DcRationalNumberType(0, 0)
     evsemaximum_charge_power: Optional[DcRationalNumberType] = DcRationalNumberType(0, 0)
-    _evsemaximum_discharge_power: Optional[DcRationalNumberType] = DcRationalNumberType(0, 0)
+    _evsemaximum_charge_power: Optional[DcRationalNumberType] = DcRationalNumberType(0, 0)
     evmaximum_discharge_power: Optional[DcRationalNumberType] = DcRationalNumberType(0, 0)
     _evmaximum_discharge_power: Optional[DcRationalNumberType] = DcRationalNumberType(0, 0)
     evmaximum_charge_power: Optional[DcRationalNumberType] = DcRationalNumberType(0, 0)


### PR DESCRIPTION
Fixed wrong parameter: `_evsemaximum_discharge_power` was typed in twice, should be `_evsemaximum_charge_power` instead. Caused an `AttributeError` during some runs with the gui.